### PR TITLE
Fixed loot fabricator resetting loot configuration

### DIFF
--- a/src/main/java/mustapelto/deepmoblearning/common/tiles/TileEntityLootFabricator.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/tiles/TileEntityLootFabricator.java
@@ -26,8 +26,10 @@ public class TileEntityLootFabricator extends TileEntityMachine {
 
             MetadataDataModel newMetadata = getPristineMatterMetadata().orElse(null);
             if (pristineMatterMetadata != newMetadata) {
-                pristineMatterMetadata = newMetadata;
-                outputItemIndex = -1;
+                if (newMetadata != null) {
+                    pristineMatterMetadata = newMetadata;
+                    outputItemIndex = -1;
+                }
                 resetCrafting();
             }
         }
@@ -194,7 +196,6 @@ public class TileEntityLootFabricator extends TileEntityMachine {
     @Override
     public void handleUpdateData(ByteBuf buf) {
         super.handleUpdateData(buf);
-        pristineMatterMetadata = inputPristineMatter.getPristineMatterMetadata().orElse(null);
         outputItemIndex = buf.readInt();
     }
 


### PR DESCRIPTION
This machine should now keep settings after running out of pristines. I used v0.8.0-beta as base so this can be published as quickfix.