### PR TITLE
Switch to FG2.3, update MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@ build
 # other
 eclipse
 run
-
-# Files from Forge MDK
-forge*changelog.txt
+logs
+*.gz

--- a/build.gradle
+++ b/build.gradle
@@ -1,89 +1,63 @@
 buildscript {
     repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
-        mavenCentral()
+        maven { url = 'https://maven.minecraftforge.net/' }
+        // maven { url = 'https://repo.spongepowered.org/maven' }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:3.+'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        // classpath 'org.spongepowered:mixingradle:0.6-SNAPSHOT'
     }
 }
-        
-apply plugin: 'net.minecraftforge.gradle'
-// Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
-apply plugin: 'idea'
-apply plugin: 'maven-publish'
 
-def mc_version = '1.12.2'
-def jei_version = '4.16.1.302'
+apply plugin: 'net.minecraftforge.gradle.forge'
+// apply plugin: 'org.spongepowered.mixin'
 
 version = '1.12.2-0.8.1-beta'
-group = 'mustapelto.dml-relearned' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+group = 'mustapelto.dml-relearned'
 archivesBaseName = 'dml-relearned'
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = '1.8'
+compileJava {
+    sourceCompatibility = targetCompatibility = '1.8'
+}
 
 minecraft {
-    mappings channel: 'snapshot', version: '20171003-1.12'
-    runs {
-        client {
-            workingDirectory project.file('run')
-
-            // Recommended logging data for a userdev environment
-            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-        }
-
-        server {
-
-            // Recommended logging data for a userdev environment
-            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-        }
-    }
+    version = '1.12.2-14.23.5.2847'
+    runDir = "run"
+    mappings = "stable_39"
+    useDepAts = true
 }
 
 repositories {
     maven {
-        name "JEI"
-        url "https://dvs1.progwml6.com/files/maven"
-    }
-    maven {
-        name "CurseMaven"
+        name "CurseForge"
         url "https://www.cursemaven.com"
     }
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2854'
-    compile 'com.google.guava:guava:30.1-jre'
+    deobfCompile "curse.maven:jei-238222:3040523"
+    compile "curse.maven:patchouli-306770:3162874"
 
-    compileOnly fg.deobf("mezz.jei:jei_${mc_version}:${jei_version}:api")
-    runtimeOnly fg.deobf("mezz.jei:jei_${mc_version}:${jei_version}")
-
-    compile 'curse.maven:patchouli-306770:3162874'
+    // compile "com.google.guava:guava:30.1-jre"
 }
 
-// Example for how to get properties into the manifest for reading by the runtime..
-jar {
-    manifest {
-        attributes([
-            "Specification-Title": "deepmoblearning",
-            "Specification-Vendor": "mustapelto",
-            "Specification-Version": "1", // We are version 1 of ourselves
-            "Implementation-Title": project.name,
-            "Implementation-Version": "${version}",
-            "Implementation-Vendor" :"mustapelto",
-            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
-        ])
+processResources {
+    inputs.property "version", project.version
+    inputs.property "mcversion", project.minecraft.version
+
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
+        expand 'version':project.version, 'mcversion':project.minecraft.version
+    }
+
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'mcmod.info'
     }
 }
 
-// Example configuration to allow publishing using the maven-publish task
-// This is the preferred method to reobfuscate your jar file
-jar.finalizedBy('reobfJar') 
-// However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
-//publish.dependsOn('reobfJar')
+// sourceSets {
+//     main {
+//         ext.refMap = "mixins.dmlrelearned.refmap.json"
+//     }
+// }

--- a/src/main/java/mustapelto/deepmoblearning/DMLRelearned.java
+++ b/src/main/java/mustapelto/deepmoblearning/DMLRelearned.java
@@ -68,7 +68,7 @@ public class DMLRelearned
 
     public static final CreativeTabs creativeTab = new CreativeTabs(DMLConstants.ModInfo.ID) {
         @Override
-        public ItemStack getTabIconItem() {
+        public ItemStack createIcon() {
             return new ItemStack(DMLRegistry.ITEM_DEEP_LEARNER);
         }
     };

--- a/src/main/java/mustapelto/deepmoblearning/client/ModelRegistry.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/ModelRegistry.java
@@ -41,7 +41,7 @@ public class ModelRegistry {
             ResourceLocation registryName = item.getRegistryName();
             if (registryName == null)
                 return;
-            String registryItem = registryName.getResourcePath();
+            String registryItem = registryName.getPath();
             modelLocation = new ResourceLocation(DMLConstants.ModInfo.ID, registryItem);
         } else {
             // Default model registration

--- a/src/main/java/mustapelto/deepmoblearning/client/models/ModelDataModel.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/models/ModelDataModel.java
@@ -55,13 +55,13 @@ public class ModelDataModel implements IModel {
 
         @Override
         public boolean accepts(ResourceLocation modelLocation) {
-            return modelLocation.getResourceDomain().equals(DMLConstants.ModInfo.ID)
-                    && modelLocation.getResourcePath().contains("data_model");
+            return modelLocation.getNamespace().equals(DMLConstants.ModInfo.ID)
+                    && modelLocation.getPath().contains("data_model");
         }
 
         @Override
         public IModel loadModel(ResourceLocation modelLocation) throws Exception {
-            String mobId = modelLocation.getResourcePath().substring("data_model_".length());
+            String mobId = modelLocation.getPath().substring("data_model_".length());
 
             ModelDataModel model;
             if (!modelCache.containsKey(mobId)) {

--- a/src/main/java/mustapelto/deepmoblearning/client/models/ModelLivingMatter.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/models/ModelLivingMatter.java
@@ -52,13 +52,13 @@ public class ModelLivingMatter implements IModel {
 
         @Override
         public boolean accepts(ResourceLocation modelLocation) {
-            return modelLocation.getResourceDomain().equals(DMLConstants.ModInfo.ID)
-                    && modelLocation.getResourcePath().contains("living_matter");
+            return modelLocation.getNamespace().equals(DMLConstants.ModInfo.ID)
+                    && modelLocation.getPath().contains("living_matter");
         }
 
         @Override
         public IModel loadModel(ResourceLocation modelLocation) throws Exception {
-            String livingMatterId = modelLocation.getResourcePath().substring("living_matter_".length());
+            String livingMatterId = modelLocation.getPath().substring("living_matter_".length());
 
             ModelLivingMatter model;
             if (!modelCache.containsKey(livingMatterId)) {

--- a/src/main/java/mustapelto/deepmoblearning/client/models/ModelPristineMatter.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/models/ModelPristineMatter.java
@@ -52,13 +52,13 @@ public class ModelPristineMatter implements IModel {
 
         @Override
         public boolean accepts(ResourceLocation modelLocation) {
-            return modelLocation.getResourceDomain().equals(DMLConstants.ModInfo.ID)
-                    && modelLocation.getResourcePath().contains("pristine_matter");
+            return modelLocation.getNamespace().equals(DMLConstants.ModInfo.ID)
+                    && modelLocation.getPath().contains("pristine_matter");
         }
 
         @Override
         public IModel loadModel(ResourceLocation modelLocation) throws Exception {
-            String mobId = modelLocation.getResourcePath().substring("pristine_matter_".length());
+            String mobId = modelLocation.getPath().substring("pristine_matter_".length());
 
             ModelPristineMatter model;
             if (!modelCache.containsKey(mobId)) {

--- a/src/main/java/mustapelto/deepmoblearning/client/util/StringAnimator.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/util/StringAnimator.java
@@ -96,7 +96,7 @@ public class StringAnimator {
         private final String string; // The string to animate
         private final float speed; // Speed of animation (in ticks/letter)
         private final float duration; // Duration of animation (in ticks)
-        private final float formattedLength; // Length of string when not counting MC formatting characters (e.g. "§d")
+        private final float formattedLength; // Length of string when not counting MC formatting characters (e.g. "ï¿½d")
         private final boolean loop; // Does the animation loop?
 
         private float position; // Current position (in ticks)
@@ -115,7 +115,7 @@ public class StringAnimator {
 
             // Filter out MC formatting symbols for length calculation
             for (int i = 0; i < string.length(); i++) {
-                if (string.charAt(i) != '§') {
+                if (string.charAt(i) != '\u00a7') {
                     tempActualLength++; // Count non-formatting chars
                 } else {
                     i++; // Skip second char of formatting symbol
@@ -155,7 +155,7 @@ public class StringAnimator {
             int endIndex = 0;
             int lettersAdded = 0; // counts "actual letters" added to output (excluding formatting characters)
             for (int i = 0; i < string.length() && lettersAdded <= floatIndex; i++) {
-                if (string.charAt(i) == '§') { // Start of MC formatting character
+                if (string.charAt(i) == '\u00a7') { // Start of MC formatting character
                     if (i < string.length() - 1) { // Not currently at last character in string
                         endIndex += 2; // Add this and following character to output
                     }

--- a/src/main/java/mustapelto/deepmoblearning/common/DMLRegistry.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/DMLRegistry.java
@@ -140,7 +140,7 @@ public class DMLRegistry {
         EntityEntry itemGlitchFragment = EntityEntryBuilder.create()
                 .entity(EntityItemGlitchFragment.class)
                 .id(itemGlitchFragmentRegistryName, entityId++)
-                .name(itemGlitchFragmentRegistryName.getResourcePath())
+                .name(itemGlitchFragmentRegistryName.getPath())
                 .tracker(64, 1, true)
                 .build();
 

--- a/src/main/java/mustapelto/deepmoblearning/common/blocks/BlockBase.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/blocks/BlockBase.java
@@ -18,7 +18,7 @@ public abstract class BlockBase extends Block {
     protected BlockBase(String name, Material material) {
         super(material);
         setRegistryName(name);
-        setUnlocalizedName(DMLConstants.ModInfo.ID + "." + name);
+        setTranslationKey(DMLConstants.ModInfo.ID + "." + name);
         setCreativeTab(DMLRelearned.creativeTab);
         setLightLevel(1f);
     }

--- a/src/main/java/mustapelto/deepmoblearning/common/blocks/BlockTileEntity.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/blocks/BlockTileEntity.java
@@ -117,7 +117,7 @@ public abstract class BlockTileEntity extends BlockBase {
     @SuppressWarnings("deprecation")
     @Override
     public IBlockState getStateFromMeta(int meta) {
-        return getDefaultState().withProperty(FACING, EnumFacing.getHorizontal(meta));
+        return getDefaultState().withProperty(FACING, EnumFacing.byHorizontalIndex(meta));
     }
 
     @Override

--- a/src/main/java/mustapelto/deepmoblearning/common/items/ItemBase.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/items/ItemBase.java
@@ -12,7 +12,7 @@ public abstract class ItemBase extends Item {
      */
     public ItemBase(String name, int stackSize, boolean addToCreative) {
         setRegistryName(name);
-        setUnlocalizedName(DMLConstants.ModInfo.ID + "." + name);
+        setTranslationKey(DMLConstants.ModInfo.ID + "." + name);
         setMaxStackSize(stackSize);
         if (addToCreative) // only add mod-dependent item to creative tab if its associated mod is loaded (checked by subclass)
             setCreativeTab(DMLRelearned.creativeTab);

--- a/src/main/java/mustapelto/deepmoblearning/common/items/ItemDeepLearner.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/items/ItemDeepLearner.java
@@ -81,7 +81,7 @@ public class ItemDeepLearner extends ItemBase {
         NonNullList<ItemStack> items = NonNullList.withSize(ContainerDeepLearner.INTERNAL_SLOTS, ItemStack.EMPTY);
         NBTTagList inventory = NBTHelper.getTagList(deepLearner, "inventory");
 
-        if (!inventory.hasNoTags()) {
+        if (!inventory.isEmpty()) {
             for (int i = 0; i < inventory.tagCount(); i++) {
                 NBTTagCompound tagCompound = inventory.getCompoundTagAt(i);
                 items.set(i, new ItemStack(tagCompound));

--- a/src/main/java/mustapelto/deepmoblearning/common/items/ItemGlitchArmor.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/items/ItemGlitchArmor.java
@@ -37,7 +37,7 @@ public abstract class ItemGlitchArmor extends ItemArmor {
     public ItemGlitchArmor(String name, EntityEquipmentSlot slot) {
         super(material, 0, slot);
         setRegistryName(name);
-        setUnlocalizedName(DMLConstants.ModInfo.ID + "." + name);
+        setTranslationKey(DMLConstants.ModInfo.ID + "." + name);
         setCreativeTab(DMLRelearned.creativeTab);
     }
 

--- a/src/main/java/mustapelto/deepmoblearning/common/items/ItemGlitchSword.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/items/ItemGlitchSword.java
@@ -38,7 +38,7 @@ public class ItemGlitchSword extends ItemSword {
         super(material);
         String name = "glitch_infused_sword";
         setRegistryName(name);
-        setUnlocalizedName(DMLConstants.ModInfo.ID + "." + name);
+        setTranslationKey(DMLConstants.ModInfo.ID + "." + name);
         setCreativeTab(DMLRelearned.creativeTab);
     }
 

--- a/src/main/java/mustapelto/deepmoblearning/common/tiles/TileEntityMachine.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/tiles/TileEntityMachine.java
@@ -239,7 +239,7 @@ public abstract class TileEntityMachine extends TileEntityContainer implements I
 
     public void onNeighborChange() {
         boolean oldRedstonePowerState = redstonePowered;
-        redstoneLevel = world.isBlockIndirectlyGettingPowered(pos);
+        redstoneLevel = world.getRedstonePowerFromNeighbors(pos);
         redstonePowered = redstoneLevel > 0;
 
         if (redstonePowered != oldRedstonePowerState) {

--- a/src/main/java/mustapelto/deepmoblearning/common/util/NBTHelper.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/util/NBTHelper.java
@@ -39,7 +39,7 @@ public class NBTHelper {
 
         nbt.removeTag(key);
 
-        if (nbt.hasNoTags())
+        if (nbt.isEmpty())
             stack.setTagCompound(null);
     }
 


### PR DESCRIPTION
- Switches to ForgeGradle 2.3 from 3.0 (3.0 causes many issues in 1.12, and it would be easier to just avoid having to debug these)
- Updates MCP from `snapshot_20171003` to `stable_39`
    - All of the code changes in this PR are just method renames from this update
- Adds (commented out) lines in `build.gradle` for Mixin, if needed in the future all that will need to be done is uncommenting the code in the file